### PR TITLE
feat(android): add ROM document picker flow (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Quest-focused Virtual Boy emulator project (Quest 2+ baseline).
 - Real Virtual Boy emulation core integrated: `libretro/beetle-vb-libretro` (Mednafen VB).
 - OpenXR stereo renderer integrated (Quest-ready path) with fallback flat GLES renderer.
 - Core is forced to `side-by-side` 3D mode and each eye samples its respective half.
-- ROM auto-load probes:
+- ROM loading:
+  - SAF file picker supports arbitrary ROM filenames.
+  - Auto-load probes (fallback):
   - `/sdcard/Download/test.vb`
   - `/sdcard/Download/test.vboy`
   - `/sdcard/Download/rom.vb`
@@ -49,6 +51,7 @@ adb push your_game.vb /sdcard/Download/test.vb
 ```
 
 5. Launch app from Unknown Sources.
+6. If no fallback ROM is found, the picker opens and you can choose any `.vb/.vboy` file.
 
 ## Input Mapping
 - D-pad: VB left D-pad

--- a/app/src/main/cpp/libretro_vb_core.h
+++ b/app/src/main/cpp/libretro_vb_core.h
@@ -24,6 +24,7 @@ public:
     void shutdown();
 
     bool loadRomFromFile(const std::string& path);
+    bool loadRomFromBytes(const uint8_t* data, size_t size, const std::string& nameHint);
     void unloadRom();
 
     void setInputState(const VbInputState& inputState);
@@ -50,6 +51,7 @@ private:
     int frameWidth_ = 0;
     int frameHeight_ = 0;
     uint16_t inputMask_ = 0;
+    std::string romPathLabel_ = "memory.vb";
     std::vector<uint8_t> romData_;
     std::vector<uint32_t> frameBuffer_;
     std::string lastError_;

--- a/app/src/main/java/com/keitark/virtualvirtualboy/MainActivity.kt
+++ b/app/src/main/java/com/keitark/virtualvirtualboy/MainActivity.kt
@@ -1,5 +1,64 @@
 package com.keitark.virtualvirtualboy
 
 import android.app.NativeActivity
+import android.content.Intent
+import android.database.Cursor
+import android.net.Uri
+import android.os.Bundle
+import android.provider.OpenableColumns
 
-class MainActivity : NativeActivity()
+class MainActivity : NativeActivity() {
+    external fun nativeOnRomSelected(data: ByteArray, displayName: String)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    fun openRomPicker() {
+        runOnUiThread {
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                addCategory(Intent.CATEGORY_OPENABLE)
+                type = "*/*"
+            }
+            startActivityForResult(intent, REQUEST_CODE_PICK_ROM)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode != REQUEST_CODE_PICK_ROM || resultCode != RESULT_OK) {
+            return
+        }
+
+        val uri = data?.data ?: return
+        try {
+            val flags = data.flags and
+                (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+            contentResolver.takePersistableUriPermission(uri, flags)
+        } catch (_: SecurityException) {
+            // Non-persistable providers are still fine for immediate load.
+        }
+
+        val displayName = queryDisplayName(uri) ?: (uri.lastPathSegment ?: "picked.vb")
+        val payload = contentResolver.openInputStream(uri)?.use { it.readBytes() } ?: return
+        if (payload.isEmpty()) {
+            return
+        }
+        nativeOnRomSelected(payload, displayName)
+    }
+
+    private fun queryDisplayName(uri: Uri): String? {
+        val cursor: Cursor = contentResolver.query(uri, null, null, null, null) ?: return null
+        cursor.use {
+            val nameIndex = it.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (nameIndex >= 0 && it.moveToFirst()) {
+                return it.getString(nameIndex)
+            }
+        }
+        return null
+    }
+
+    private companion object {
+        const val REQUEST_CODE_PICK_ROM = 1001
+    }
+}


### PR DESCRIPTION
## Linked issue
Fixes #1

## Summary
- Add Android Storage Access Framework ROM picker in `MainActivity`.
- Bridge selected ROM bytes/name to native via `nativeOnRomSelected` JNI.
- Queue pending ROM bytes thread-safely in native app loop and load from memory.
- Keep fallback auto-load paths and add manual picker trigger (`X` button).
- Update README ROM-loading notes to document arbitrary filename support.

## Test evidence
- Build passed with JDK 17:
  - `$env:JAVA_HOME='C:\Program Files\Eclipse Adoptium\jdk-17.0.18.8-hotspot'; $env:Path="$env:JAVA_HOME\\bin;$env:Path"; ./gradlew assembleDebug`

## Impact/Risk notes
- Positive: app is no longer restricted to hardcoded ROM filenames.
- Risk: large ROMs are copied into memory for JNI handoff; acceptable for VB ROM sizes but worth monitoring.
- Risk: picker UX depends on SAF provider behavior across Android versions.