### PR TITLE
docs(repo): polish GitHub page metadata and README entry (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # virtualvirtualboy
 
 [![Status](https://img.shields.io/badge/status-beta-orange?style=for-the-badge)](https://github.com/Keitark/virtualvirtualboy/releases)
+[![Release](https://img.shields.io/github/v/tag/Keitark/virtualvirtualboy?sort=semver&style=for-the-badge)](https://github.com/Keitark/virtualvirtualboy/releases)
 [![Platform](https://img.shields.io/badge/platform-Android%20(Quest)-3DDC84?style=for-the-badge)](https://developer.android.com/)
 [![OpenXR](https://img.shields.io/badge/OpenXR-1.1-0066B8?style=for-the-badge)](https://www.khronos.org/openxr/)
 [![License](https://img.shields.io/badge/license-MIT-blue?style=for-the-badge)](LICENSE)
@@ -9,6 +10,11 @@
 Virtual Boy emulator for Meta Quest (Quest 2+), implemented as a native Android + OpenXR app.
 
 Current milestone: `v0.1.0-beta.1`
+
+Project links:
+- Releases: <https://github.com/Keitark/virtualvirtualboy/releases>
+- Issues: <https://github.com/Keitark/virtualvirtualboy/issues>
+- Discussions/feedback: open an Issue with the `type: feature` label.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add release badge to README header
- Add quick project links (Releases/Issues/feedback)
- Improve GitHub repository page metadata (description/homepage/topics)
- Publish `v0.1.0-beta.1` as a GitHub pre-release from existing tag

## Linked Issue
Fixes #14

## Test Evidence
- `gh repo view --json description,homepageUrl,repositoryTopics`
- `gh release list --limit 5`
- README renders with updated badges and links

## Impact / Risk
- No runtime code changes
- Documentation and repository presentation only
