### PR TITLE
fix(input): correct inverted up/down mapping on Quest (#24)

### DIFF
--- a/app/src/main/cpp/native_app.cpp
+++ b/app/src/main/cpp/native_app.cpp
@@ -522,8 +522,8 @@ public:
 
             stickLeft_ = stickX < -kStickDeadzone || hatX < -kHatThreshold;
             stickRight_ = stickX > kStickDeadzone || hatX > kHatThreshold;
-            stickUp_ = stickY < -kStickDeadzone || hatY < -kHatThreshold;
-            stickDown_ = stickY > kStickDeadzone || hatY > kHatThreshold;
+            stickUp_ = stickY > kStickDeadzone || hatY > kHatThreshold;
+            stickDown_ = stickY < -kStickDeadzone || hatY < -kHatThreshold;
             triggerAxisL_ = lTrigger > kTriggerThreshold;
             triggerAxisR_ = rTrigger > kTriggerThreshold;
 

--- a/app/src/main/cpp/xr_stereo_renderer.cpp
+++ b/app/src/main/cpp/xr_stereo_renderer.cpp
@@ -750,8 +750,8 @@ void XrStereoRenderer::syncInput() {
 
     controllerState_.left = move.x < -kDeadzone;
     controllerState_.right = move.x > kDeadzone;
-    controllerState_.up = move.y < -kDeadzone;
-    controllerState_.down = move.y > kDeadzone;
+    controllerState_.up = move.y > kDeadzone;
+    controllerState_.down = move.y < -kDeadzone;
 
     controllerState_.a = getBooleanActionState(buttonAAction_);
     controllerState_.b = getBooleanActionState(buttonBAction_);


### PR DESCRIPTION
## Summary
- Swap vertical axis mapping for Quest input paths so Up/Down are no longer inverted
- Apply fix in both:
  - Android motion event path (`native_app.cpp`)
  - OpenXR controller path (`xr_stereo_renderer.cpp`)

## Linked Issue
Fixes #24

## Test Evidence
- Local build succeeded: `./gradlew assembleDebug` (JDK 17)
- Attempted reinstall/launch via ADB, but no device was connected at execution time

## Impact / Risk
- Only vertical direction sign changed
- No change to other button/axis mappings
